### PR TITLE
Quickfix for xjm project to unlock build pipeline

### DIFF
--- a/xjm/Dockerfile
+++ b/xjm/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update && apt-get install -y \
   s3cmd \
   build-essential \
   patch \
+  libxml2-utils \
   libmagic-dev=1:5.14-2ubuntu3.3 \
   zlib1g-dev=1:1.2.8.dfsg-1ubuntu1 \
   ruby2.2=2.2.4-1bbox1~trusty1 \


### PR DESCRIPTION
We forgot to install libxml2-utils
Related to https://github.com/teamed/xockets-xjm/issues/798
@yegor256 I would really appreciate quick turnaround here.
Thanks!