### PR TITLE
Unlocked ruby versions

### DIFF
--- a/xht/Dockerfile
+++ b/xht/Dockerfile
@@ -37,8 +37,8 @@ RUN apt-get update && apt-get install -y \
   lsof \
   libmagic-dev=1:5.14-2ubuntu3.3 \
   zlib1g-dev=1:1.2.8.dfsg-1ubuntu1 \
-  ruby2.2=2.2.4-1bbox1~trusty1 \
-  ruby2.2-dev=2.2.4-1bbox1~trusty1 \
+  ruby2.2 \
+  ruby2.2-dev \
   && rm -rf /var/lib/apt/lists/*
 
 RUN gem update && gem install \


### PR DESCRIPTION
Trying to solve issue [2216](https://github.com/teamed/xockets-hadoop-transport/issues/2216) from XHT project.

As [advised](https://github.com/teamed/xockets-hadoop-transport/issues/2216#issuecomment-269994840), I unlocked the ruby versions since the Dockerfile could not be built because of them (see [here](https://github.com/teamed/xockets-hadoop-transport/issues/2231))

After I unlocked them, I built the image and ``lsof`` command is found. On the other hand, if I pull yegor256/xht image, ``lsof`` is not found.