### PR TITLE
yegor256/rultor -> yegor256/rultor-image

### DIFF
--- a/java8/Dockerfile
+++ b/java8/Dockerfile
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-FROM yegor256/rultor
+FROM yegor256/rultor-image
 MAINTAINER Yegor Bugayenko <yegor@teamed.io>
 LABEL Description="Java8" Vendor="Yegor Bugayenko" Version="1.0"
 


### PR DESCRIPTION
Updated the root Docker image. Docker image ``yegor256/rultor`` has been replaced with ``yegor256/rultor-image``