### PR TITLE
Install `texlive-fonts-recommended` in `latex` image

### DIFF
--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get -y -q update \
     imagemagick=* \
     ghostscript=* \
     qpdf=* \
-    texlive-fonts-recommended \
+    texlive-fonts-recommended=2020.20210202-3 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -5,6 +5,8 @@ FROM yegor256/ruby:0.0.1
 LABEL description="RULTOR image for simple LaTeX projects"
 LABEL version="0.0.1"
 
+WORKDIR /tmp
+
 SHELL ["/bin/bash", "-e", "-c", "-o", "pipefail"]
 
 RUN apt-get -y -q update \

--- a/latex/Dockerfile
+++ b/latex/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get -y -q update \
     imagemagick=* \
     ghostscript=* \
     qpdf=* \
+    texlive-fonts-recommended \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This PR adds `texlive-fonts-recommended` into `latex` image.

Closes #23 