### PR TITLE
Increase timeout in `make` workflow to 30 minutes

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -12,7 +12,7 @@ name: make
       - master
 jobs:
   make:
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: ubuntu-24.04
     env:
       PLATFORMS: ''


### PR DESCRIPTION
This PR increases timeout in `make` workflow to 30 minutes to prevent it from failure due to exceeding the allocated time period.

Closes #27 