### PR TITLE
fix(extras): add --yes to apt-get install in install-ab.sh

### DIFF
--- a/extras/install-ab.sh
+++ b/extras/install-ab.sh
@@ -6,7 +6,7 @@
 set -ex -o pipefail
 
 apt-get update --yes --fix-missing
-apt-get install apache2-utils
+apt-get install --yes apache2-utils
 apt-get clean
 
 ab -V


### PR DESCRIPTION
Fixes #51.

`extras/install-ab.sh` line 9 ran `apt-get install apache2-utils` without `--yes`. In a non-interactive shell with no stdin (CI such as Rultor), apt stops at `Do you want to continue? [Y/n]` and blocks until timeout. Since a base-image rebuild, `apache2-utils` pulls new dependencies (`libapr1t64`, `libaprutil1t64`), so the prompt now triggers. `set -e` doesn't help because the process blocks before any exit code is produced.

This change adds `--yes`, matching every sibling script (e.g. `extras/install-node.sh`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dskj7tPPXCGeaBabAnqhLs)_