### PR TITLE
fix(extras): remove OSS4 ALSA shims before installing Chrome

### DIFF
--- a/extras/install-chrome.sh
+++ b/extras/install-chrome.sh
@@ -11,6 +11,7 @@ apt-get install --yes chromium-driver
 wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/chrome-keyring.gpg
 echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
 apt-get update --yes --fix-missing
+apt-get remove --yes liboss4-salsa-asound2 liboss4-salsa2
 apt-get install --yes google-chrome-stable
 apt-get remove --yes --purge chromium-driver
 apt-get clean


### PR DESCRIPTION
## Problem

`extras/install-chrome.sh:14` (`apt-get install --yes google-chrome-stable`) fails in the current `yegor256/java` image. The image ships `liboss4-salsa-asound2` and `liboss4-salsa2` pre-installed, and `liboss4-salsa-asound2` declares `Conflicts: libasound2` — the very package `google-chrome-stable` depends on.

apt cannot install `libasound2` without removing the OSS4 shim, and since nothing requests that removal it errors out (`pkgProblemResolver::Resolve generated breaks`). Nothing in the image depends on the OSS4 shims, so they are dead weight that breaks every Chrome install.

## Fix

Remove the unused `liboss4-salsa-asound2` and `liboss4-salsa2` packages before installing `google-chrome-stable`, per the issue's verified recommendation.

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtVnXTujwNaA6bwHKszRrR)_