### PR TITLE
Fix #55: keep temurin JDK when installing Chrome

### DIFF
--- a/extras/install-chrome.sh
+++ b/extras/install-chrome.sh
@@ -11,6 +11,11 @@ apt-get install --yes chromium-driver
 wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/chrome-keyring.gpg
 echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
 apt-get update --yes --fix-missing
+# Install the real libasound2 first, so packages that depend on it (e.g.
+# temurin-*-jdk) keep their dependency satisfied. Otherwise removing the
+# oss4 packages below cascades into removing the JDK, breaking JAVA_HOME
+# (see #55, regression from #53).
+apt-get install --yes libasound2
 apt-get remove --yes liboss4-salsa-asound2 liboss4-salsa2
 apt-get install --yes google-chrome-stable
 apt-get remove --yes --purge chromium-driver


### PR DESCRIPTION
Fixes #55.

## Problem

After `extras/install-chrome.sh` ran, `mvn` (and anything using Java) failed instantly with `The JAVA_HOME environment variable is not defined correctly`. `$JAVA_HOME` still pointed at `/usr/lib/jvm/temurin-21-jdk-amd64`, but the directory was gone.

The line added in #53 to resolve the Chrome/liboss4 conflict:

```bash
apt-get remove --yes liboss4-salsa-asound2 liboss4-salsa2
```

cascaded into removing `temurin-21-jdk`, because the JDK depends on `libasound2` and that dependency was satisfied only by `liboss4-salsa-asound2`. Removing the oss4 package dragged the JDK out with it.

## Fix

Install the real `libasound2` *before* removing the oss4 packages. With a genuine `libasound2` provider present, the JDK's dependency stays satisfied and it is no longer removed when the oss4 packages go away. Chrome's `libasound2` requirement is likewise met.

This is the issue author's primary suggested fix, and it is version-agnostic — `install-chrome.sh` is generic and used across images, so reinstalling `temurin-21-jdk` explicitly would be wrong for non-Java images.

## Verification

Docker is not available in this environment, so I could not run the reproduction here. The change should be confirmed with:

```bash
docker run --rm --platform linux/amd64 yegor256/java:0.0.1 bash -c '
  /usr/bin/install-chrome.sh
  mvn -version        # should succeed
  google-chrome --version
'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYvtLsXnpSuJAepsnvrmBT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYvtLsXnpSuJAepsnvrmBT)_