### PR TITLE
fix(extras): use libasound2t64 instead of virtual libasound2 on Noble

### DIFF
--- a/extras/install-chrome.sh
+++ b/extras/install-chrome.sh
@@ -14,8 +14,10 @@ apt-get update --yes --fix-missing
 # Install the real libasound2 first, so packages that depend on it (e.g.
 # temurin-*-jdk) keep their dependency satisfied. Otherwise removing the
 # oss4 packages below cascades into removing the JDK, breaking JAVA_HOME
-# (see #55, regression from #53).
-apt-get install --yes libasound2
+# (see #55, regression from #53). On Ubuntu Noble the `libasound2` name is
+# a virtual package (time64 transition), so install the concrete
+# `libasound2t64`, which provides it (see #58).
+apt-get install --yes libasound2t64
 apt-get remove --yes liboss4-salsa-asound2 liboss4-salsa2
 apt-get install --yes google-chrome-stable
 apt-get remove --yes --purge chromium-driver


### PR DESCRIPTION
Follow-up to #55, fixes #58.

On Ubuntu Noble the `libasound2` package is **virtual** (the time64 transition renamed it to `libasound2t64`), so `apt-get install --yes libasound2` has no install candidate and aborts under `set -e`, killing the build:

```
E: Package 'libasound2' has no installation candidate
```

## Fix

Install the concrete `libasound2t64` package in `extras/install-chrome.sh`. It provides the virtual `libasound2` (satisfying Chrome's dependency) and, since it conflicts with `liboss4-salsa-asound2`, installing it replaces the oss4 package. The subsequent `apt-get remove ... liboss4-salsa-asound2` then reports "not installed", and `temurin-21-jdk` is never touched.

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T85Nk1ZxMXBhEPxMJcetSv)_