### PR TITLE
fix: declare imagemagick explicitly in ruby image (#60)

### DIFF
--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
     curl=* wget=* \
     git=* \
     gnupg2=* \
+    imagemagick=* \
     jq=* \
     libcurl4-gnutls-dev=* \
     libjpeg-dev=* \

--- a/tests/test-ruby.sh
+++ b/tests/test-ruby.sh
@@ -14,6 +14,8 @@ zip -h | head -1
 unzip -h | head -1
 ssh -V
 git --version
+identify --version
+convert --version
 docker --version
 docker buildx version
 


### PR DESCRIPTION
Fixes #60.

## Problem

`yegor256/java:0.0.1` (and the `ruby`/`latex` images it shares a base with) lost ImageMagick after a recent rebuild. `identify`/`convert` went missing, breaking downstream builds that use `mini_magick` (e.g. `zerocracy/baza`):

```
`identify -format %m %w %h %b ...png` failed with status: 127
executable not found: "identify"
```

ImageMagick was never declared in `ruby/Dockerfile` or `java/Dockerfile` — it was only ever present **transitively**, so a base-image refresh silently dropped it.

## Fix

- Declare `imagemagick=*` explicitly in `ruby/Dockerfile`'s `apt-get install` block, alphabetically placed. Since `java/Dockerfile` and `latex/Dockerfile` both build `FROM yegor256/ruby:0.0.1`, this restores ImageMagick across all downstream images. (`latex/Dockerfile` already declared it for its own use.)
- Add `identify --version` / `convert --version` assertions to `tests/test-ruby.sh` so this regression can't silently recur.

The IM6 legacy `identify`/`convert` commands are exactly what `mini_magick` 5.x invokes — no IM7 `magick` binary is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KdoVpr2YhA4V2MncAa3Yi

---
_Generated by [Claude Code](https://claude.ai/code/session_014KdoVpr2YhA4V2MncAa3Yi)_